### PR TITLE
add support for Ubuntu's clang-format

### DIFF
--- a/whatstyle.py
+++ b/whatstyle.py
@@ -6598,6 +6598,7 @@ def formatterclass(fmtname):
     fmtname = fmtname.lower()
     for prefix, fmtclass in [
         ('clang-format', ClangFormatter),
+        ('Ubuntu clang-format', ClangFormatter),
         ('LLVM', ClangFormatter),
         ('yapf', YapfFormatter),
         ('uncrustify', UncrustifyFormatter),


### PR DESCRIPTION
Unfortunately, some Ubuntu packages add a "Ubuntu prefix" to their clang-format binaries:
```
$ clang-format --version
Ubuntu clang-format version 12.0.0-3ubuntu1~20.04.4
```

This small change allows using those as well.